### PR TITLE
Fixed string quotes when using newline escape seq.

### DIFF
--- a/compiler/constructs/c_return.php
+++ b/compiler/constructs/c_return.php
@@ -23,7 +23,7 @@ class c_return extends BaseConstruct
 //            return "return " . $this->expr->emit(true) . ";\n";
 //        }
         if ($this->expr == ';') {
-            return 'return Runtime::$undefined;\n';
+            return "return Runtime::\$undefined;\n";
         } else {
             return "return " . $this->expr->emit(true) . ";\n";
         }


### PR DESCRIPTION
Fixes the `Class 'nRuntime' not found` error in the compiled code:

```php
if (Runtime::js_bool(Runtime::idv('_initialized'))) return Runtime::$undefined;\nRuntime::expr_assign(Runtime::id('_initialized'),Runtime::$true);
```